### PR TITLE
Feature/14

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { StyleSheet, View, Text } from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
+import PropTypes from "prop-types";
+
+const List = ({ plans, onClickPlan, dotColor }) => {
+  return (
+    <View style={styles.planContainer}>
+      {Object.entries(plans).map(([id, plan]) => {
+        const date = new Date(plan.date);
+        const year = date.getFullYear();
+        const month = date.getMonth() + 1;
+        const day = date.getDate();
+        const time = date.toLocaleTimeString().substring(0, 5);
+
+        return (
+          <TouchableOpacity
+            key={id}
+            style={styles.inlineContainer}
+            onPress={() => onClickPlan(id)}
+          >
+            <View style={styles.dot(dotColor)} />
+            <View style={styles.textContainer}>
+              <Text>{plan.place}</Text>
+              <Text>{`${year}년 ${month}월 ${day}일 ${time} `}</Text>
+              <View style={styles.friendContainer}>
+                <Text>with. </Text>
+                {plan.friends.map((friend) => (
+                  <Text key={friend._id} style={styles.friend}>
+                    {friend.name}
+                  </Text>
+                ))}
+              </View>
+            </View>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  planContainer: {
+    flex: 2,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#fff",
+  },
+  inlineContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    borderBottomColor: "#898989",
+    borderBottomWidth: 1,
+  },
+  dot: (dotColor) => ({
+    width: 10,
+    height: 10,
+    marginTop: 30,
+    marginRight: 10,
+    borderRadius: 100,
+    backgroundColor: dotColor,
+  }),
+  textContainer: {
+    marginTop: 10,
+    marginBottom: 10,
+  },
+  friendContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  friend: {
+    marginRight: 3,
+  },
+});
+
+List.propTypes = {
+  plans: PropTypes.object.isRequired,
+  onClickPlan: PropTypes.func.isRequired,
+  dotColor: PropTypes.string,
+};
+
+export default List;

--- a/src/navigation/DrawerNavigator.js
+++ b/src/navigation/DrawerNavigator.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { createDrawerNavigator } from "@react-navigation/drawer";
 
-import { MainStack, MyPickStack } from "./StackNavigator";
+import { MainStack, MyPickStack, VoteStack } from "./StackNavigator";
 import MakeAPlanScreen from "../screens/MakeAPlanScreen";
 
 const Drawer = createDrawerNavigator();
@@ -32,6 +32,11 @@ const DrawerNavigator = () => {
         name="MakeAPlan"
         component={MakeAPlanScreen}
         options={{ drawerLabel: "Make a Plan" }}
+      />
+      <Drawer.Screen
+        name="PickVote"
+        component={VoteStack}
+        options={{ drawerLabel: "Vote List" }}
       />
     </Drawer.Navigator>
   );

--- a/src/navigation/StackNavigator.js
+++ b/src/navigation/StackNavigator.js
@@ -7,6 +7,7 @@ import PlanListScreen from "../screens/PlanListScreen";
 import PlanDetailScreen from "../screens/PlanDetailScreen";
 import MyPickScreen from "../screens/MyPickScreen";
 import NewMyPickScreen from "../screens/NewMyPickScreen";
+import VoteListScreen from "../screens/VoteListScreen";
 
 const Main = createStackNavigator();
 
@@ -58,5 +59,19 @@ export const MyPickStack = () => {
         options={{ title: "New My Pick" }}
       />
     </MyPick.Navigator>
+  );
+};
+
+const Vote = createStackNavigator();
+
+export const VoteStack = () => {
+  return (
+    <Vote.Navigator initialRouteName="VoteList">
+      <Vote.Screen
+        name="VoteList"
+        component={VoteListScreen}
+        options={{ title: "Vote List" }}
+      />
+    </Vote.Navigator>
   );
 };

--- a/src/navigation/StackNavigator.js
+++ b/src/navigation/StackNavigator.js
@@ -8,6 +8,7 @@ import PlanDetailScreen from "../screens/PlanDetailScreen";
 import MyPickScreen from "../screens/MyPickScreen";
 import NewMyPickScreen from "../screens/NewMyPickScreen";
 import VoteListScreen from "../screens/VoteListScreen";
+import VoteScreen from "../screens/VoteScreen";
 
 const Main = createStackNavigator();
 
@@ -71,6 +72,11 @@ export const VoteStack = () => {
         name="VoteList"
         component={VoteListScreen}
         options={{ title: "Vote List" }}
+      />
+      <Vote.Screen
+        name="Vote"
+        component={VoteScreen}
+        options={{ title: "Vote" }}
       />
     </Vote.Navigator>
   );

--- a/src/screens/MakeAPlanScreen.js
+++ b/src/screens/MakeAPlanScreen.js
@@ -102,7 +102,7 @@ function MakeAPlanScreen({ navigation }) {
                 index: 0,
                 routes: [
                   {
-                    name: "Main",
+                    name: "PickVote",
                   },
                 ],
               })

--- a/src/screens/PlanListScreen.js
+++ b/src/screens/PlanListScreen.js
@@ -1,13 +1,13 @@
 import React, { useEffect } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { StyleSheet, Text, View } from "react-native";
-import { TouchableOpacity } from "react-native-gesture-handler";
 import asyncStorage from "@react-native-async-storage/async-storage";
 import PropTypes from "prop-types";
 
 import { getPlanList } from "../../util/api/planList";
 import { userState } from "../states/userState";
 import { planState } from "../states/planState";
+import PlanList from "../components/List";
 
 export default function PlanListScreen({ navigation }) {
   const user = useRecoilValue(userState);
@@ -41,37 +41,11 @@ export default function PlanListScreen({ navigation }) {
       <View style={styles.container}>
         <Text style={styles.title}>My Plan List</Text>
       </View>
-      <View style={styles.planContainer}>
-        {Object.entries(plans).map(([id, plan]) => {
-          const date = new Date(plan.date);
-          const year = date.getFullYear();
-          const month = date.getMonth() + 1;
-          const day = date.getDate();
-          const time = date.toLocaleTimeString().substring(0, 5);
-
-          return (
-            <TouchableOpacity
-              key={id}
-              style={styles.inlineContainer}
-              onPress={() => navigateDetailPage(id)}
-            >
-              <View style={styles.circle} />
-              <View style={styles.textContainer}>
-                <Text>{plan.place}</Text>
-                <Text>{`${year}년 ${month}월 ${day}일 ${time} `}</Text>
-                <View style={styles.friendContainer}>
-                  <Text>with. </Text>
-                  {plan.friends.map((friend) => (
-                    <Text key={friend._id} style={styles.friend}>
-                      {friend.name}
-                    </Text>
-                  ))}
-                </View>
-              </View>
-            </TouchableOpacity>
-          );
-        })}
-      </View>
+      <PlanList
+        plans={plans}
+        onClickPlan={navigateDetailPage}
+        dotColor="#90b189"
+      />
       <View style={styles.emptyContainer} />
     </>
   );
@@ -85,39 +59,8 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
   },
   title: {
-    color: "#0A80AE",
+    color: "#0a80ae",
     fontSize: 45,
-  },
-  planContainer: {
-    flex: 2,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#fff",
-  },
-  inlineContainer: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    borderBottomColor: "#898989",
-    borderBottomWidth: 1,
-  },
-  circle: {
-    width: 10,
-    height: 10,
-    marginTop: 30,
-    marginRight: 10,
-    borderRadius: 100,
-    backgroundColor: "#90B189",
-  },
-  textContainer: {
-    marginTop: 10,
-    marginBottom: 10,
-  },
-  friendContainer: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-  },
-  friend: {
-    marginRight: 3,
   },
   emptyContainer: {
     flex: 1,

--- a/src/screens/VoteListScreen.js
+++ b/src/screens/VoteListScreen.js
@@ -1,11 +1,48 @@
-import React from "react";
-import { StyleSheet, View, Text } from "react-native";
+import React, { useEffect } from "react";
+import { StyleSheet, View, Text, ScrollView } from "react-native";
+import { useRecoilState, useRecoilValue } from "recoil";
+import PropTypes from "prop-types";
 
-export default function VoteListScreen() {
+import { getVoteListApi } from "../../util/api/voteList";
+import { userState } from "../states/userState";
+import { voteState } from "../states/voteState";
+import VoteList from "../components/List";
+
+export default function VoteListScreen({ navigation }) {
+  const user = useRecoilValue(userState);
+  const [votes, setVotes] = useRecoilState(voteState);
+
+  useEffect(() => {
+    const getVoteList = async () => {
+      try {
+        const voteList = await getVoteListApi(user.userId);
+
+        setVotes(voteList.data);
+      } catch (err) {
+        alert("error");
+      }
+    };
+
+    getVoteList();
+  }, []);
+
+  const navigateVotePage = (voteId) => {
+    navigation.navigate("Vote", { voteId: voteId });
+  };
+
   return (
-    <View style={styles.container}>
-      <Text>Vote List Screen</Text>
-    </View>
+    <>
+      <View style={styles.container}>
+        <Text style={styles.title}>Vote List</Text>
+        <ScrollView>
+          <VoteList
+            plans={votes}
+            onClickPlan={navigateVotePage}
+            dotColor="#f5ba6a"
+          />
+        </ScrollView>
+      </View>
+    </>
   );
 }
 
@@ -14,5 +51,17 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    backgroundColor: "#fff",
+  },
+  title: {
+    flex: 1,
+    color: "#0a80ae",
+    fontSize: 45,
   },
 });
+
+VoteListScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+};

--- a/src/screens/VoteScreen.js
+++ b/src/screens/VoteScreen.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { StyleSheet, View, Text } from "react-native";
+
+export default function VoteScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Vote Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/states/voteState.js
+++ b/src/states/voteState.js
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const voteState = atom({
+  key: "votes",
+  default: {},
+});

--- a/util/api/voteList.js
+++ b/util/api/voteList.js
@@ -1,0 +1,7 @@
+import axios from "../../src/config/axiosConfig";
+
+export const getVoteListApi = async (userId) => {
+  const response = await axios.get(`/users/${userId}/plan/votelist`);
+
+  return response.data;
+};


### PR DESCRIPTION
# [11] {Vote-List screen}

## 노션 칸반 링크
​- [Vote-List screen] (https://instinctive-maple-d7e.notion.site/Front-Vote-List-screen-0b68dc5dce334e5d9de31c06d0dd752f)

## 카드에서 구현 혹은 해결하려는 내용
-  list render 하기 위해 Vote list get 요청
- list component 분리해서 재활용
- 클릭시 해당 약속의 vote screen 로 이동

❗️현재 리스트가 날짜순이 아닌 저장순이어서 날짜순으로 리팩토링하면 좋을듯 
