### PR TITLE
Feature/16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ environment.js
 .husky/
 google-services.json
 .idea/
+.vscode
 
 # macOS
 .DS_Store

--- a/src/navigation/StackNavigator.js
+++ b/src/navigation/StackNavigator.js
@@ -9,6 +9,7 @@ import MyPickScreen from "../screens/MyPickScreen";
 import NewMyPickScreen from "../screens/NewMyPickScreen";
 import VoteListScreen from "../screens/VoteListScreen";
 import VoteScreen from "../screens/VoteScreen";
+import VoteResultScreen from "../screens/VoteResultScreen";
 
 const Main = createStackNavigator();
 
@@ -77,6 +78,11 @@ export const VoteStack = () => {
         name="Vote"
         component={VoteScreen}
         options={{ title: "Vote" }}
+      />
+      <Vote.Screen
+        name="VoteResult"
+        component={VoteResultScreen}
+        options={{ title: "Vote Result" }}
       />
     </Vote.Navigator>
   );

--- a/src/screens/MakeAPlanScreen.js
+++ b/src/screens/MakeAPlanScreen.js
@@ -85,7 +85,9 @@ function MakeAPlanScreen({ navigation }) {
       placeLocation: [latitude, longitude],
       date: date,
       friends: friendsId,
+      voting: [],
       pickNumber: pickValue,
+      picks: [],
       isVoted: false,
       isFixed: false,
     };

--- a/src/screens/VoteListScreen.js
+++ b/src/screens/VoteListScreen.js
@@ -16,7 +16,6 @@ export default function VoteListScreen({ navigation }) {
     const getVoteList = async () => {
       try {
         const voteList = await getVoteListApi(user.userId);
-
         setVotes(voteList.data);
       } catch (err) {
         alert("error");
@@ -27,7 +26,31 @@ export default function VoteListScreen({ navigation }) {
   }, []);
 
   const navigateVotePage = (voteId) => {
-    navigation.navigate("Vote", { voteId: voteId });
+    Object.entries(votes).map(([id, plan]) => {
+      if (voteId === id) {
+        if (!plan.voting.length) {
+          navigation.navigate("Vote", { voteId: voteId });
+
+          return;
+        }
+
+        const isNotVotedUser = plan.voting.every((votedPick) => {
+          return votedPick.id !== user.userId;
+        });
+
+        if (isNotVotedUser) {
+          navigation.navigate("Vote", { voteId: voteId });
+
+          return;
+        }
+
+        if (!isNotVotedUser) {
+          navigation.navigate("VoteResult", { voteId: voteId });
+
+          return;
+        }
+      }
+    });
   };
 
   return (

--- a/src/screens/VoteResultScreen.js
+++ b/src/screens/VoteResultScreen.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { StyleSheet, View, Text } from "react-native";
+
+function VoteResultScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Vote result screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+
+export default VoteResultScreen;

--- a/src/screens/VoteScreen.js
+++ b/src/screens/VoteScreen.js
@@ -1,11 +1,244 @@
-import React from "react";
-import { StyleSheet, View, Text } from "react-native";
+import React, { useEffect, useState } from "react";
+import {
+  StyleSheet,
+  View,
+  Text,
+  Dimensions,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+} from "react-native";
+import { useRecoilValue } from "recoil";
+import MapView, { Marker } from "react-native-maps";
+import PropTypes from "prop-types";
 
-export default function VoteScreen() {
+import { getPicksApi } from "../../util/api/voteList";
+import { getMyPicks } from "../../util/api/myPick";
+import VoteButton from "../components/Button";
+import { userState } from "../states/userState";
+
+function VoteScreen({ route }) {
+  const user = useRecoilValue(userState);
+  const userId = user.userId;
+  const planId = route.params.voteId;
+  const [clickedPick, setClickedPick] = useState(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [friendsPicks, setFriendsPicks] = useState(null);
+  const [myPicks, setMyPicks] = useState(null);
+  const [place, setPlace] = useState(null);
+  const [vote, setVote] = useState([]);
+
+  useEffect(() => {
+    const getPicks = async () => {
+      try {
+        const picks = await getPicksApi({ userId, planId });
+        const myPicks = await getMyPicks(userId);
+
+        setFriendsPicks(picks.data.friendsPicks);
+        setMyPicks(myPicks.data);
+        setPlace(picks.data.place);
+      } catch (err) {
+        alert("error");
+      }
+    };
+
+    getPicks();
+  }, []);
+
+  const handleVoteButtonClick = (userId) => {};
+
+  const handleMarkerClick = (pickId) => {
+    Object.entries(friendsPicks).map(([id, pick]) => {
+      if (pickId === id) {
+        setClickedPick({ id: id, pick: pick });
+        setModalVisible(true);
+      }
+    });
+
+    Object.entries(myPicks).map(([id, pick]) => {
+      if (pickId === id) {
+        setClickedPick({ id: id, pick: pick });
+        setModalVisible(true);
+      }
+    });
+  };
+
+  const handlePickButtonClick = () => {
+    const isNotDuplicate = vote.every((pick) => {
+      return pick.id !== clickedPick.id;
+    });
+
+    if (isNotDuplicate) {
+      setVote([...vote, { id: clickedPick.id, info: clickedPick.pick }]);
+      setModalVisible(false);
+    }
+
+    if (!isNotDuplicate) {
+      alert("중복으로 투표할 수 없습니다❗️");
+    }
+  };
   return (
-    <View style={styles.container}>
-      <Text>Vote Screen</Text>
-    </View>
+    <>
+      <View style={styles.container}>
+        <Modal
+          animationType="fade"
+          visible={modalVisible}
+          transparent={true}
+          onRequestClose={() => {
+            setModalVisible(!modalVisible);
+          }}
+        >
+          <View style={styles.centeredView}>
+            <View style={styles.modalView}>
+              <Pressable
+                style={styles.button}
+                onPress={() => setModalVisible(!modalVisible)}
+              >
+                <Text style={styles.buttonTextStyle}>X</Text>
+              </Pressable>
+              <ScrollView style={{ width: "90%", height: "90%" }}>
+                <Text style={styles.pickText}>
+                  <Text style={styles.formText}>Name: </Text>
+                  {clickedPick?.pick.name}
+                </Text>
+                <Text style={styles.pickText}>
+                  <Text style={styles.formText}>Address: </Text>
+                  {clickedPick?.pick.address}
+                </Text>
+                <Text style={styles.pickText}>
+                  <Text style={styles.formText}>Rating: </Text>
+                  {clickedPick?.pick.rating}
+                </Text>
+                <Text style={styles.pickText}>
+                  <Text style={styles.formText}>Type: </Text>
+                  {clickedPick?.pick.type}
+                </Text>
+                {clickedPick?.pick.image ? (
+                  <Image
+                    source={{
+                      uri: clickedPick?.pick.image,
+                    }}
+                    style={{ width: 290, height: 200 }}
+                  />
+                ) : (
+                  <Text> </Text>
+                )}
+                <View style={styles.modalButtonContainer}>
+                  <VoteButton
+                    width={80}
+                    height={50}
+                    title="Pick"
+                    size={15}
+                    onPress={(ev) => handlePickButtonClick()}
+                  />
+                </View>
+              </ScrollView>
+            </View>
+          </View>
+        </Modal>
+        <MapView
+          style={styles.map}
+          initialRegion={{
+            latitude: place?.placeLocation[0],
+            longitude: place?.placeLocation[1],
+            latitudeDelta: 0.02,
+            longitudeDelta: 0.01,
+          }}
+        >
+          {friendsPicks &&
+            Object.entries(friendsPicks).map(([id, pick]) => {
+              const latitude = pick.location[0];
+              const longitude = pick.location[1];
+              let image;
+
+              switch (pick.type) {
+                case "meal":
+                  image = require("../../assets/meal.png");
+                  break;
+                case "pup":
+                  image = require("../../assets/pup.png");
+                  break;
+                case "cafe":
+                  image = require("../../assets/cafe.png");
+                  break;
+                default:
+                  image = require("../../assets/pin.png");
+              }
+
+              return (
+                <Marker
+                  key={id}
+                  coordinate={{ latitude: latitude, longitude: longitude }}
+                  title={pick.name}
+                  onPress={(ev) => handleMarkerClick(id)}
+                >
+                  <Image source={image} style={{ width: 30, height: 30 }} />
+                </Marker>
+              );
+            })}
+          {myPicks &&
+            Object.entries(myPicks).map(([id, pick]) => {
+              const latitude = pick.location[0];
+              const longitude = pick.location[1];
+              let image;
+
+              switch (pick.type) {
+                case "meal":
+                  image = require("../../assets/meal.png");
+                  break;
+                case "pup":
+                  image = require("../../assets/pup.png");
+                  break;
+                case "cafe":
+                  image = require("../../assets/cafe.png");
+                  break;
+                default:
+                  image = require("../../assets/pin.png");
+              }
+
+              return (
+                <Marker
+                  key={id}
+                  coordinate={{ latitude: latitude, longitude: longitude }}
+                  title={pick.name}
+                  onPress={(ev) => handleMarkerClick(id)}
+                >
+                  <Image source={image} style={{ width: 30, height: 30 }} />
+                </Marker>
+              );
+            })}
+        </MapView>
+        <View style={styles.pickContainer}>
+          <Text style={{ marginTop: 10, fontSize: 30, color: "#0a80ae" }}>
+            MY PICK
+          </Text>
+          <Text style={{ color: "#CFCFCF" }}>
+            가고싶은 장소의 마커를 클릭해서 투표해주세요
+          </Text>
+          <View style={{ marginTop: "3%" }}>
+            {vote &&
+              vote.map((pick) => {
+                return (
+                  <Text
+                    key={pick.id}
+                    style={{ fontSize: 15, marginBottom: "1%" }}
+                  >
+                    ✅ {pick.info.name}
+                  </Text>
+                );
+              })}
+          </View>
+        </View>
+        <VoteButton
+          width={86}
+          height={8}
+          title="VOTE"
+          size={20}
+          onPress={() => handleVoteButtonClick(userId)}
+        />
+      </View>
+    </>
   );
 }
 
@@ -14,5 +247,86 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    paddingBottom: 16,
+    backgroundColor: "#fff",
+  },
+  map: {
+    width: Dimensions.get("window").width,
+    height: 300,
+  },
+  buttonContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 240,
+    backgroundColor: "#fff",
+  },
+  centeredView: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 22,
+  },
+  modalView: {
+    width: 350,
+    height: 350,
+    margin: 20,
+    backgroundColor: "#fff",
+    borderRadius: 20,
+    padding: 15,
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  modalButtonContainer: {
+    flex: 1,
+    width: "100%",
+    height: 70,
+    alignItems: "center",
+    marginTop: "3%",
+  },
+  button: {
+    width: 40,
+    height: 40,
+    marginLeft: 260,
+    borderRadius: 100,
+    padding: 10,
+    elevation: 2,
+    backgroundColor: "#d3edf7",
+  },
+  buttonTextStyle: {
+    color: "#898989",
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  pickText: {
+    marginBottom: 10,
+    color: "#898989",
+  },
+  formText: {
+    fontSize: 15,
+    color: "#0a80ae",
+  },
+  pickContainer: {
+    flex: 1,
+    alignItems: "center",
+    width: "100%",
+    backgroundColor: "#fff",
   },
 });
+
+VoteScreen.propTypes = {
+  route: PropTypes.shape({
+    params: PropTypes.shape({
+      voteId: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default VoteScreen;

--- a/src/screens/VoteScreen.js
+++ b/src/screens/VoteScreen.js
@@ -8,17 +8,19 @@ import {
   Modal,
   Pressable,
   ScrollView,
+  Alert,
 } from "react-native";
 import { useRecoilValue } from "recoil";
 import MapView, { Marker } from "react-native-maps";
+import { CommonActions } from "@react-navigation/routers";
 import PropTypes from "prop-types";
 
-import { getPicksApi } from "../../util/api/voteList";
+import { getPicksApi, postVotePickApi } from "../../util/api/voteList";
 import { getMyPicks } from "../../util/api/myPick";
 import VoteButton from "../components/Button";
 import { userState } from "../states/userState";
 
-function VoteScreen({ route }) {
+function VoteScreen({ route, navigation }) {
   const user = useRecoilValue(userState);
   const userId = user.userId;
   const planId = route.params.voteId;
@@ -46,7 +48,32 @@ function VoteScreen({ route }) {
     getPicks();
   }, []);
 
-  const handleVoteButtonClick = (userId) => {};
+  const handleVoteButtonClick = async () => {
+    try {
+      const response = await postVotePickApi({ userId, planId, vote });
+
+      if (response.result === "success") {
+        Alert.alert("Success👍🏻", "투표가 완료되었습니다.", [
+          {
+            text: "OK",
+            onPress: () =>
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [
+                    {
+                      name: "VoteList",
+                    },
+                  ],
+                })
+              ),
+          },
+        ]);
+      }
+    } catch (err) {
+      alert("error");
+    }
+  };
 
   const handleMarkerClick = (pickId) => {
     Object.entries(friendsPicks).map(([id, pick]) => {
@@ -235,7 +262,7 @@ function VoteScreen({ route }) {
           height={8}
           title="VOTE"
           size={20}
-          onPress={() => handleVoteButtonClick(userId)}
+          onPress={() => handleVoteButtonClick()}
         />
       </View>
     </>
@@ -326,6 +353,11 @@ VoteScreen.propTypes = {
     params: PropTypes.shape({
       voteId: PropTypes.string.isRequired,
     }).isRequired,
+  }).isRequired,
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func,
+    dispatch: PropTypes.func,
+    reset: PropTypes.func,
   }).isRequired,
 };
 

--- a/util/api/voteList.js
+++ b/util/api/voteList.js
@@ -12,10 +12,13 @@ export const getPicksApi = async ({ userId, planId }) => {
   return response.data;
 };
 
-export const postVotePickApi = async ({ userId, planId, votePick }) => {
-  const response = await axios.post(`/users/:userId/plan/:planId/vote/new`, {
-    votePick,
-  });
+export const postVotePickApi = async ({ userId, planId, vote }) => {
+  const response = await axios.post(
+    `/users/${userId}/plan/${planId}/vote/new`,
+    {
+      vote,
+    }
+  );
 
   return response.data;
 };

--- a/util/api/voteList.js
+++ b/util/api/voteList.js
@@ -5,3 +5,17 @@ export const getVoteListApi = async (userId) => {
 
   return response.data;
 };
+
+export const getPicksApi = async ({ userId, planId }) => {
+  const response = await axios.get(`/users/${userId}/plan/${planId}/vote`);
+
+  return response.data;
+};
+
+export const postVotePickApi = async ({ userId, planId, votePick }) => {
+  const response = await axios.post(`/users/:userId/plan/:planId/vote/new`, {
+    votePick,
+  });
+
+  return response.data;
+};


### PR DESCRIPTION
# [11] {Vote screen}

## 노션 칸반 링크
​- [Vote screen] (https://instinctive-maple-d7e.notion.site/Front-Vote-screen-fe9027d39205402883ed0ea315a15fc9)

## 카드에서 구현 혹은 해결하려는 내용
-  친구들 pick, user pick 모두 get 요청
- pick 지도에 렌더링(store에 저장하지 않기)
- marker 클릭시 가게 정보 모달창
- 모달창을 열어서 pick button 클릭시 vote list에 추가
- pick 선택 후 vote 누르면 plan의 vote에 추가(POST)
- vote 누르면 Vote list로 이동
- vote를 완료한 사람은 vote screen이 아니라 vote result 창을 보여줘야 함

❗️현재 지도의 최초위치 렌더링은 되지만, 경고메세지가 뜸 ->  렌더 순서에 문제가 있는것 같아서 리팩토링시 수정 필요
❗️길이가 너무 긴 코드들은 컴포넌트로 분리할 필요가 있음